### PR TITLE
fix: Remove 'index.php' from wc-api path

### DIFF
--- a/models/api.php
+++ b/models/api.php
@@ -108,7 +108,7 @@ class Paddle_WC_API {
      */
     private static function get_webhook_url($order_id) {
         // Adding index.php makes it work for customers without permalinks, and doesn't seem to affect ones with
-	    return get_bloginfo('url') . '/index.php/wc-api/paddle_complete?order_id=' . $order_id;
+	    return get_bloginfo('url') . '/wc-api/paddle_complete?order_id=' . $order_id;
 	}
 
     /**


### PR DESCRIPTION
In `NGINX`, `/index.php/wc-api/....` doesn't seem to be resolved correctly
It cannot find it, and returns 404 error. Causes Paddle to send such an email

`Dear {NAME} - {Order_ID}, One of your customers may not have received
their product after payment due to an issue with the custom checkout
fulfilment webhook. You may need to take action to manually make sure
the customer has access to the product they purchased. Order: {Order_ID}
Customer email: {Customer_Email} Fulfilment webhook error: 404 Do let us
know should you have any questions or concerns! Best, Paddle`

This quick fix will solve it - It took us HOURS to figure this problem,
BIG SHOUTOUT to Andrew from Kinsta Support Team for his great support!!!